### PR TITLE
Request token using POST as per the OAuth 1.0 Protocol.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,6 @@ When registering a new app, you have to specify a callback URL. Otherwise,
 it is considered as an `off-band` app and users will be given a PIN code
 instead of being redirected back to your site.
 
-Even though Twitter will not give you any error about improper callback URI,
-it'll always use the value set in app's settings page. So, if you have two
-versions, say one on `localhost` and another on `example.org`, you'll probably
-want to register two applications (e.g. `dev` and `production`) and use 
-appropriate set of key/secret accordingly.
-
 ### OpenID
 
 For OpenID to work you'll need to set `AuthenticationType` to `FederatedLogin`

--- a/simpleauth/handler.py
+++ b/simpleauth/handler.py
@@ -291,7 +291,10 @@ class SimpleAuthHandler(object):
 
     # make a request_token request
     client = self._oauth1_client(consumer_key=key, consumer_secret=secret)
-    resp, content = client.request(auth_urls['request'], "GET")
+    resp, content = client.request(auth_urls['request'],
+                                  "POST",
+                                  body=urlencode(
+                                      {'oauth_callback': callback_url}))
 
     if resp.status != 200:
       raise AuthProviderResponseError(

--- a/tests/handler_test.py
+++ b/tests/handler_test.py
@@ -31,7 +31,7 @@ class OAuth1ClientMock(object):
     self._response_content = kwargs.pop('content', '')
     self._response_dict = kwargs
 
-  def request(self, url, method):
+  def request(self, url, method, body=None):
     return (Response(self._response_dict), self._response_content)
 
 


### PR DESCRIPTION
I am not sure why you were using GET request for requesting tokens in the first place, but POST is more standard [0]. Twitter also has a [POST oauth/request_token](https://dev.twitter.com/oauth/reference/post/oauth/request_token) method. With this change, Twitter redirects to the URI specified in `oauth_callback` if present. If not, to the URI specified in the app settings page.

This means no need to register multiple applications.

I did not test the LinkedIn provider as the API is deprecated.

[0] http://oauth.net/core/1.0a/#auth_step1