### PR TITLE
add README.md to Manifest.in

### DIFF
--- a/Manifest.in
+++ b/Manifest.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Error was when `pip install simpleauth`:

```
Extracting in /tmp/tmpUdMwDx

Now working in /tmp/tmpUdMwDx/distribute-0.6.14

Building a Distribute egg in /tmp/pip-build-0FYzyO/simpleauth

/tmp/pip-build-0FYzyO/simpleauth/distribute-0.6.14-py2.7.egg

Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/tmp/pip-build-0FYzyO/simpleauth/setup.py", line 46, in <module>

    long_description=read('README.md')

  File "/tmp/pip-build-0FYzyO/simpleauth/setup.py", line 11, in read

    return open(os.path.join(os.path.dirname(__file__), fname)).read()

IOError: [Errno 2] No such file or directory: '/tmp/pip-build-0FYzyO/simpleauth/README.md'
```

.. this PR includes `README.md` in the egg's manifest and thus in the distributed package.